### PR TITLE
Use assumeArray to avoid babel using Symbols for for...of loop

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -92,23 +92,27 @@ module.exports =
 "use strict";
 
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
-function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
 
-function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
 var strictUriEncode = __webpack_require__(1);
 
@@ -352,50 +356,31 @@ function parse(input, options) {
     return ret;
   }
 
-  var _iteratorNormalCompletion = true;
-  var _didIteratorError = false;
-  var _iteratorError = undefined;
+  for (var _i2 = 0, _input$split2 = input.split('&'); _i2 < _input$split2.length; _i2++) {
+    var param = _input$split2[_i2];
 
-  try {
-    for (var _iterator = input.split('&')[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-      var param = _step.value;
-
-      var _splitOnFirst = splitOnFirst(options.decode ? param.replace(/\+/g, ' ') : param, '='),
-          _splitOnFirst2 = _slicedToArray(_splitOnFirst, 2),
-          key = _splitOnFirst2[0],
-          value = _splitOnFirst2[1]; // Missing `=` should be `null`:
-      // http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
+    var _splitOnFirst = splitOnFirst(options.decode ? param.replace(/\+/g, ' ') : param, '='),
+        _splitOnFirst2 = _slicedToArray(_splitOnFirst, 2),
+        key = _splitOnFirst2[0],
+        value = _splitOnFirst2[1]; // Missing `=` should be `null`:
+    // http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
 
 
-      value = value === undefined ? null : ['comma', 'separator'].includes(options.arrayFormat) ? value : decode(value, options);
-      formatter(decode(key, options), value, ret);
-    }
-  } catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-  } finally {
-    try {
-      if (!_iteratorNormalCompletion && _iterator["return"] != null) {
-        _iterator["return"]();
-      }
-    } finally {
-      if (_didIteratorError) {
-        throw _iteratorError;
-      }
-    }
+    value = value === undefined ? null : ['comma', 'separator'].includes(options.arrayFormat) ? value : decode(value, options);
+    formatter(decode(key, options), value, ret);
   }
 
-  for (var _i = 0, _Object$keys = Object.keys(ret); _i < _Object$keys.length; _i++) {
-    var key = _Object$keys[_i];
-    var value = ret[key];
+  for (var _i4 = 0, _Object$keys2 = Object.keys(ret); _i4 < _Object$keys2.length; _i4++) {
+    var _key = _Object$keys2[_i4];
+    var _value = ret[_key];
 
-    if (_typeof(value) === 'object' && value !== null) {
-      for (var _i2 = 0, _Object$keys2 = Object.keys(value); _i2 < _Object$keys2.length; _i2++) {
-        var k = _Object$keys2[_i2];
-        value[k] = parseValue(value[k], options);
+    if (_typeof(_value) === 'object' && _value !== null) {
+      for (var _i6 = 0, _Object$keys4 = Object.keys(_value); _i6 < _Object$keys4.length; _i6++) {
+        var k = _Object$keys4[_i6];
+        _value[k] = parseValue(_value[k], options);
       }
     } else {
-      ret[key] = parseValue(value, options);
+      ret[_key] = parseValue(_value, options);
     }
   }
 
@@ -440,8 +425,8 @@ exports.stringify = function (object, options) {
   var formatter = encoderForArrayFormat(options);
   var objectCopy = {};
 
-  for (var _i3 = 0, _Object$keys3 = Object.keys(object); _i3 < _Object$keys3.length; _i3++) {
-    var key = _Object$keys3[_i3];
+  for (var _i8 = 0, _Object$keys6 = Object.keys(object); _i8 < _Object$keys6.length; _i8++) {
+    var key = _Object$keys6[_i8];
 
     if (!shouldFilter(key)) {
       objectCopy[key] = object[key];
@@ -539,7 +524,7 @@ module.exports = function (str) {
 "use strict";
 
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 var token = '%[a-f0-9]{2}';
 var singleMatcher = new RegExp(token, 'gi');

--- a/package.json
+++ b/package.json
@@ -42,18 +42,19 @@
 	"devDependencies": {
 		"@babel/cli": "^7.2.3",
 		"@babel/core": "^7.2.2",
+		"@babel/plugin-transform-for-of": "^7.12.1",
 		"@babel/preset-env": "^7.2.3",
 		"ava": "^1.4.1",
 		"babel-loader": "^8.0.6",
-		"decode-uri-component": "^0.2.0",
 		"benchmark": "^2.1.4",
+		"decode-uri-component": "^0.2.0",
 		"deep-equal": "^1.0.1",
 		"fast-check": "^1.5.0",
 		"split-on-first": "^1.0.0",
 		"strict-uri-encode": "^2.0.0",
 		"tsd": "^0.7.3",
-		"webpack": "^4.34.0",
-		"webpack-cli": "^3.3.4",
+		"webpack": "^4.44.2",
+		"webpack-cli": "^3.3.12",
 		"xo": "^0.24.0"
 	},
 	"types": "./index.d.ts"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,12 @@ module.exports = {
 				use: {
 					loader: 'babel-loader',
 					options: {
-						presets: ['@babel/preset-env']
+						presets: ['@babel/preset-env'],
+						plugins: [
+							['@babel/plugin-transform-for-of', {
+								assumeArray: true
+							}]
+						]
 					}
 				}
 			}


### PR DESCRIPTION
This is an attempt to ensure Babel does not transform `for...of` loops to use `Symbol`, which causes issues with using this package on IE11.

The reason why this is done is because:

1. By looking through the source code we know that the original `query-string` package uses `for...of` loop to iterate arrays only, so it is safe to turn on the `assumeArray` flag
2. The transpiled version of `for...of` loop that uses Symbol [does not play well with all Symbol ponyfills I've tried](https://github.com/cdeutsch/query-string-for-all/issues/19)